### PR TITLE
issue with the begin function as master

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -295,7 +295,8 @@ void TwoWire::begin(void)
   }
 
   ROM_SysCtlPeripheralEnable(g_uli2cPeriph[i2cModule]);
-
+ while (!ROM_SysCtlPeripheralReady(g_uli2cPeriph[i2cModule]))
+ {}
   //Configure GPIO pins for I2C operation
   ROM_GPIOPinConfigure(g_uli2cConfig[i2cModule][0]);
   ROM_GPIOPinConfigure(g_uli2cConfig[i2cModule][1]);


### PR DESCRIPTION
I had been trying to work with the i2c bus with a mpu6050, but it just did not work. So I added a while right after you enable the peripheral in the begin() function as master, it just worked out for me, i followed the tivaware reference guide example for i2c initialization