### PR TITLE
Function 'attached()' added to Servo.cpp

### DIFF
--- a/libraries/Servo/Servo.cpp
+++ b/libraries/Servo/Servo.cpp
@@ -186,6 +186,10 @@ void Servo::detach()
 	digitalWrite(servos[this->index].pin_number, LOW);
 }
 
+bool Servo::attached(){
+	return servos[this->index].enabled;
+}
+
 //! ISR for generating the pulse widths
 void ServoIntHandler(void)
 {


### PR DESCRIPTION
The function 'attached()' was declared in 'Servo.h' but not defined in 'Servo.cpp'. I have added the definition for that function in 'Servo.cpp'.